### PR TITLE
Upgrade to netstandard2.1

### DIFF
--- a/SampleTests/ModelTest.cs
+++ b/SampleTests/ModelTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using SampleTests.Models;
+using Shouldly;
 using TestHelpers.Helpers;
 using Xunit;
 
@@ -34,8 +35,11 @@ namespace SampleTests
             expectedFields.Add(new NameAndType("Counter", "System.Int32", new List<string>()));
             //expectedFields.Add(new NameAndType("Name", "System.String", new List<string>()));
 
-
-            AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(ExampleModel));
+            Should.Throw<ShouldAssertException>(() =>
+            {
+                AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(ExampleModel));
+            })
+                .Message.ShouldStartWith("3\n    should be\n2\n    but was not");
         }
 
         [Fact]
@@ -50,7 +54,11 @@ namespace SampleTests
             expectedFields.Add(new NameAndType("Name", "System.String", new List<string>()));
             expectedFields.Add(new NameAndType("Name2", "System.String", new List<string>()));
 
-            AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(ExampleModel));
+            Should.Throw<ShouldAssertException>(() =>
+                {
+                    AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(ExampleModel));
+                })
+                .Message.ShouldStartWith("3\n    should be\n4\n    but was not");
         }
 
         [Fact]
@@ -62,7 +70,11 @@ namespace SampleTests
             expectedFields.Add(new NameAndType("Name", "System.String", new List<string>()));
 
 
-            AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(ExampleModel));
+            Should.Throw<ShouldAssertException>(() =>
+                {
+                    AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(ExampleModel));
+                })
+                .Message.ShouldStartWith("1\n    should be\n0\n    but was not");
         }
 
         [Fact]
@@ -76,7 +88,11 @@ namespace SampleTests
             expectedFields.Add(new NameAndType("Name", "System.String", new List<string>()));
 
 
-            AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(ExampleModel));
+            Should.Throw<ShouldAssertException>(() =>
+                {
+                    AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(ExampleModel));
+                })
+                .Message.ShouldContain("should be\n\"Not right\"\n    but was not");
         }
 
         [Fact]
@@ -91,7 +107,11 @@ namespace SampleTests
             expectedFields.Add(new NameAndType("Counter", "System.Int32", new List<string>()));
             expectedFields.Add(new NameAndType("Name", "System.String", new List<string>()));
 
-            AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(ExampleModel));
+            Should.Throw<ShouldAssertException>(() =>
+                {
+                    AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(ExampleModel));
+                })
+                .Message.ShouldStartWith("1\n    should be\n2\n    but was not");
         }
 
     }

--- a/SampleTests/SampleTests.csproj
+++ b/SampleTests/SampleTests.csproj
@@ -15,9 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="TestHelpers">
-      <HintPath>..\TestHelpers\bin\Debug\netcoreapp2.0\TestHelpers.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/SampleTests/SampleTests.csproj
+++ b/SampleTests/SampleTests.csproj
@@ -1,16 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/SampleTests/xUnitSample.cs
+++ b/SampleTests/xUnitSample.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using SampleTests.Models;
 using Shouldly;
+using TestHelpers.Helpers;
 using Xunit;
+using Xunit.Sdk;
 
 namespace SampleTests
 {
@@ -16,15 +19,15 @@ namespace SampleTests
             Assert.Equal(4, 2 + 2);
         }
 
-        [Fact(Skip = "Test skipped because it is a test of the fail")]
+        [Fact]
         public void BadMath()
         {
-            Assert.Equal(4, 1 + 1);
-        }
-        [Fact]
-        public void BadMath2()
-        {
-            Assert.Equal(4, 1 + 1);
+            
+            Should.Throw<EqualException>(() =>
+                {
+                    Assert.Equal(4, 1 + 1);
+                })
+                .Message.ShouldBe("Assert.Equal() Failure\r\nExpected: 4\r\nActual:   2");
         }
 
         [Theory]

--- a/TestHelpers/Helpers/AsyncHelper.cs
+++ b/TestHelpers/Helpers/AsyncHelper.cs
@@ -41,9 +41,9 @@ namespace TestHelpers.Helpers
             return new TestAsyncEnumerable<TResult>(expression);
         }
 
-        public Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
+        public TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
         {
-            return Task.FromResult(Execute<TResult>(expression));
+            return Execute<TResult>(expression);
         }
     }
 
@@ -57,10 +57,10 @@ namespace TestHelpers.Helpers
             : base(expression)
         { }
 
-        //public IAsyncEnumerator<T> GetAsyncEnumerator()
-        //{
-        //    return new TestAsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
-        //}
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new TestAsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
+        }
 
 
 
@@ -84,15 +84,21 @@ namespace TestHelpers.Helpers
             _inner = inner;
         }
 
-        public void Dispose()
+        public ValueTask DisposeAsync()
         {
             _inner.Dispose();
+            return new ValueTask();
         }
 
-        //public Task<bool> MoveNextAsync(CancellationToken cancellationToken)
-        //{
-        //    return Task.FromResult(_inner.MoveNext());
-        //}
+        public ValueTask<bool> MoveNextAsync(CancellationToken cancellationToken)
+        {
+            return  new ValueTask<bool>(_inner.MoveNext());
+        }
+
+        public ValueTask<bool> MoveNextAsync()
+        {
+            return new ValueTask<bool>(_inner.MoveNext());
+        }
 
         public Task<bool> MoveNext(CancellationToken cancellationToken)
         {

--- a/TestHelpers/Helpers/MockExtensions.cs
+++ b/TestHelpers/Helpers/MockExtensions.cs
@@ -23,7 +23,7 @@ namespace TestHelpers.Helpers
             var mockSet = new Mock<DbSet<T>>();
 
             mockSet.As<IAsyncEnumerable<T>>()
-                .Setup(m => m.GetEnumerator())
+                .Setup(m => m.GetAsyncEnumerator(default))
                 .Returns(new TestAsyncEnumerator<T>(data.GetEnumerator()));
 
 

--- a/TestHelpers/Helpers/MockExtensions.cs
+++ b/TestHelpers/Helpers/MockExtensions.cs
@@ -15,6 +15,7 @@ namespace TestHelpers.Helpers
             mockSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(data.Expression);
             mockSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(data.ElementType);
             mockSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(data.GetEnumerator());
+            mockSet.As<IEnumerable<T>>().Setup(x => x.GetEnumerator()).Returns(data.GetEnumerator());
             return mockSet;
         }
 
@@ -33,6 +34,9 @@ namespace TestHelpers.Helpers
 
             mockSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(data.Expression);
             mockSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(data.ElementType);
+
+            mockSet.As<IQueryable<T>>().Setup(x => x.GetEnumerator()).Returns(data.GetEnumerator());
+            mockSet.As<IEnumerable<T>>().Setup(x => x.GetEnumerator()).Returns(data.GetEnumerator());
 
             return mockSet;
         }

--- a/TestHelpers/TestHelpers.csproj
+++ b/TestHelpers/TestHelpers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -7,6 +7,10 @@
     <Authors>Jason Sylvestre</Authors>
     <Description>Test Helpers for .NET Core</Description>
     <PackageProjectUrl>https://github.com/ucdavis/TestHelpers</PackageProjectUrl>
+    <Nullable>annotations</Nullable>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestHelpers/TestHelpers.csproj
+++ b/TestHelpers/TestHelpers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageId>AspNetCore.TestHelpers</PackageId>
     <Authors>Jason Sylvestre</Authors>
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.2" />
-    <PackageReference Include="Moq" Version="4.8.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.11" />
+    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Wasn't sure whether I should bump the major version. Decided not to, since the API has not changed.

The tests all pass now. Don't worry, I didn't change the meaning of them; only made them indicate that they made the validation tests fail as expected.

Not sure how to get this published to nuget.